### PR TITLE
Fix calling `.empty?` on `nil` (Faraday Monkey Patch)

### DIFF
--- a/lib/yodleeicious.rb
+++ b/lib/yodleeicious.rb
@@ -12,7 +12,8 @@ require File.dirname(__FILE__) + "/yodleeicious/yodlee_api"
 
 class Faraday::Adapter::NetHttp
   def net_http_connection(env)
-    if !(proxy = env[:request][:proxy]).empty?
+    proxy = env[:request][:proxy]
+    if proxy && !proxy.empty?
       if proxy[:socks]
         # TCPSocket.socks_username = proxy[:user] if proxy[:user]
         # TCPSocket.socks_password = proxy[:password] if proxy[:password]


### PR DESCRIPTION
If  `env[:request][:proxy]` was `nil` an error would be raised as `nil` does not have `.empty?`. This caused problems with code that used Faraday (such as librato-rack).
