### PR TITLE
Set the status code in the Response

### DIFF
--- a/lib/yodleeicious/response.rb
+++ b/lib/yodleeicious/response.rb
@@ -2,8 +2,7 @@ module Yodleeicious
   class Response
 
     def initialize res, payload=nil
-      @body = JSON.parse(res.body)
-      @request_url = begin res.env.url.to_s rescue nil end
+      @res = res
       @payload = payload
     end
 
@@ -16,7 +15,7 @@ module Yodleeicious
     end
 
     def body
-      @body
+      @body ||= JSON.parse(@res.body)
     end
 
     def payload
@@ -24,7 +23,13 @@ module Yodleeicious
     end
 
     def request_url
-      @request_url
+      @res.env.url.to_s
+    rescue
+      nil
+    end
+
+    def status
+      @res.status
     end
 
     def response

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -31,6 +31,10 @@ describe 'the yodlee api client integration tests', integration: true do
     it 'sets payload' do
       expect(subject.payload).not_to be_nil
     end
+
+    it 'sets the status code' do
+      expect(subject.status).not_to be_nil
+    end
   end
 
 

--- a/spec/unit/yodleeicious/response_spec.rb
+++ b/spec/unit/yodleeicious/response_spec.rb
@@ -34,6 +34,10 @@ describe Yodleeicious::Response do
     it 'sets payload' do
       expect(subject.payload).not_to be_nil
     end
+
+    it 'sets the status code' do
+      expect(subject.status).not_to be_nil
+    end
   end
 
 


### PR DESCRIPTION
We want to access the status code of the response so that we can save it in our records as well. 

To access:
res = Response.new(response, params)
res.status
=> 200

And also, I modified the body and request_url methods a bit.
